### PR TITLE
Add map to Connect page

### DIFF
--- a/ourSites.html
+++ b/ourSites.html
@@ -272,8 +272,13 @@
         </div>
       </div>
     </div>
+    </div>
+    <div class = "basic-box">
+      <h2>Community Network Sites Map</h2>
+      <iframe src="https://www.google.com/maps/d/embed?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F&z=10&sll=47.551951079942704, -122.28761910549852" allowfullscreen class= "map"></iframe>
+    </div>
 
-    <div class="landing-tan">
+    <div class="landing-tan" style="margin-bottom: 50px;" >
       <h2> Coverage Map </h2>
       <button onclick="location.href=''" type="button" id="network-button">
         Our latest coverage estimates &rarr;

--- a/style.css
+++ b/style.css
@@ -437,6 +437,16 @@ top: 833px;
 background: #FFFFFF;
 transform: rotate(-180deg);
 */
+.map{
+  width: 100%;
+    max-width: 1000px;
+    height: 500px;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+
+}
+
 .wave-container {
   background-image: url("assets/landing\ page\ banner.png");
 }


### PR DESCRIPTION
Esther requested that the google map is embedded in the Connect page. I am currently reading documentation about adding the search bar to the map directly, but currently the user will have to press the expand button to view the search button for now. 
This is a draft to show what the map will look like on the website, feel free to request any text/design changes!