### PR TITLE
Fix card display issues and broken buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
   <div class="img-wrapper">
     <img id="city-graphic" src="assets/City Graphic.png" alt="image of buildings">
     <div class="overlay">
-      <button onclick="location.href='https://docs.seattlecommunitynetwork.org/get-started.html'" type="button"
+      <button onclick="location.href='https://docs.seattlecommunitynetwork.org/community/join.html'" type="button"
         id="get-involved-button">
         Get Involved &rarr;
       </button>

--- a/ourSites.html
+++ b/ourSites.html
@@ -5,7 +5,7 @@
 <head>
   <!-- probably on all pages -->
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
   <link rel="stylesheet" href="style.css">
 
 </head>
@@ -316,9 +316,7 @@
       </div>
     </div>
   </div>
-  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/ourSites.html
+++ b/ourSites.html
@@ -5,8 +5,7 @@
 <head>
   <!-- probably on all pages -->
 
-  <link rel="stylesheet" href="bootstrap-5.0.1-dist/css/bootstrap.css">
-  <script src="bootstrap-5.0.1-dist/js/bootstrap.bundle.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
   <link rel="stylesheet" href="style.css">
 
 </head>
@@ -25,7 +24,7 @@
 
   <!--NAV BAR CODE-->
   <nav class="navbar navbar-expand-lg navbar-light bg-white">
-    <div class="container-fluid">
+    <div class="container">
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarText"
         aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -128,207 +127,198 @@
     </p>
   </div>
 
-  <div class="landing-tan">
-    <h2>Locations (Listed N to S)</h2>
-    <!--
-      <ul class = "bulleted-list">
-        <li class = "bulleted-list-point">Garfield High School</li>
-        <li class = "bulleted-list-point">Franklin High School</li>
-        <li class = "bulleted-list-point">Filipino Community Center</li>
-        <li class = "bulleted-list-point">Oromo Cultural Center</li>
-        <li class = "bulleted-list-point">KCLS Skyway Library</li>
-        <li class = "bulleted-list-point">Surge Tacoma</li>
-      </ul> 
-    </div>
-  -->
-
-    <!-- SITE MODULE CARDS  -->
-    <div class="flex-container-row-to-col">
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/Garfield.png" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://garfieldhs.seattleschools.org/" class="site-name">Garfield High School</a>
-          <p class="card-texty img-wrapper">
-            Address: 400 23rd Ave, Seattle, WA 98122
-            <br>
-            Description: Estimated coverage area lies to the east of highway I-5, and to the north of E Yesler Way.
-            Coverage extends east as far as 34th Ave, but east of 23rd Ave it has a northern boundary at E Union St. To
-            the west of 23rd Ave, the northern boundary is E John St. and E Thomas St. See green portions of the <a
-              href="https://drive.google.com/file/d/1uzo6_0qQoQbPqGSrWemU61mHuoEpWOGW/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
+  <div class="container">
+    <h2>Coverage Areas</h2>
+    <h6 class="text-center text-muted mb-4">Ordered North to South</h6>
+    <!-- SITE CARDS  -->
+    <div class="row">
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/Garfield.png">
+            <img src="assets/static-maps/Garfield.png" class="card-img-top" alt="A map of Garfield High School coverage area">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5><a href="assets/static-maps/Garfield.png">Garfield High School Area</a></h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>400 23rd Ave, Seattle, WA 98122</h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area lies to the east of highway I-5, and to the north of E Yesler Way. Coverage extends east as far as 34th Ave, but east of 23rd Ave it has a northern boundary at E Union St. To the west of 23rd Ave, the northern boundary is E John St. and E Thomas St. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for details.
+            </p>
+          </div>
         </div>
       </div>
-
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/Franklin.jpeg" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://franklinhs.seattleschools.org/" class="site-name">Franklin High School</a>
-          <p class="card-texty img-wrapper">
-            Address: 3013 S Mt Baker Blvd, Seattle, WA 98144
-            <br>
-            Description: Estimated coverage area lies to the south of S Mt. Baker Blvd and to the north of S Orcas St.
-            Going east to west, it lies between 24th Ave S and 42nd Ave S to the north of Rainier Playfield, and between
-            28th Ave S and Wilson Ave S to the south of Rainier Playfield. See green portions of the <a
-              href="https://drive.google.com/file/d/1SabotFa2dgXj_7VPG9uwBkWalih5spe1/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/Franklin.jpeg">
+            <img src="assets/static-maps/Franklin.jpeg" class="card-img-top" alt="A map of the Franklin High School coverage area.">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5><a href="assets/static-maps/Franklin.jpeg" class="card-title">Franklin High School Area</a></h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>3013 S Mt Baker Blvd, Seattle, WA 98144</h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area lies to the south of S Mt. Baker Blvd and to the north of S Orcas St. Going east to west, it lies between 24th Ave S and 42nd Ave S to the north of Rainier Playfield, and between 28th Ave S and Wilson Ave S to the south of Rainier Playfield. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for more details.
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-
-
-
-    <div class="flex-container-row-to-col">
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/FCV.jpeg" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://www.filcommsea.org/" class="site-name">Filipino Community Center</a>
-          <p class="card-texty img-wrapper">
-            Address: 5740 Martin Luther King Jr Way S, Seattle, WA 98118
-            <br>
-            Description: Estimated coverage area currently lies between 32nd Ave S and 39th Ave S going west to east,
-            and between S Dawson St and S Holly St going north to south. See green portions of the <a
-              href="https://drive.google.com/file/d/1QB4IakU_JYDLWO5WIBrbLmi1xPhryF1x/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/FCV.jpeg">
+            <img src="assets/static-maps/FCV.jpeg" class="card-img-top" alt="A map of the Filipino Community Center coverage area.">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5>
+                <a href="./assets/static-maps/FCV.jpeg" class="card-title">Filipino Community Center Area</a>
+              </h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>
+                5740 Martin Luther King Jr Way S, Seattle, WA 98118
+              </h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area currently lies between 32nd Ave S and 39th Ave S going west to east,
+              and between S Dawson St and S Holly St going north to south. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for more details.
+            </p>
+          </div>
         </div>
       </div>
-
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/OCC.png" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://www.facebook.com/OromoCC/" class="site-name">Oromo Cultural Center</a>
-          <p class="card-texty img-wrapper">
-            Address: 8819 Renton Ave S, Seattle, WA 98118
-            <br>
-            Description: Estimated coverage area lies to the south of S Cloverdale St, east of MLK Jr. Way S, west of
-            Rainier Ave S, and north of S Fletcher St. See green portions of the <a
-              href="https://drive.google.com/file/d/1Nqps9n1p8t75xgnO1vNpXkzwFo1Q2HQN/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/OCC.png">
+            <img src="assets/static-maps/OCC.png" class="card-img-top" alt="A map of the Oromo Cultural Center coverage area.">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5>
+                <a href="assets/static-maps/OCC.png" class="card-title">Oromo Cultural Center Area</a>
+              </h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>
+                8819 Renton Ave S, Seattle, WA 98118
+              </h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area lies to the south of S Cloverdale St, east of MLK Jr. Way S, west of Rainier Ave S, and north of S Fletcher St. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for more details.
+            </p>
+          </div>
         </div>
       </div>
-    </div>
-
-    <div class="flex-container-row-to-col">
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/SkywayLibrary.jpeg" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://kcls.org/locations/skyway/" class="site-name">KCLS Skyway Library</a>
-          <p class="card-texty img-wrapper">
-            Address: 12601 76th Ave S, Seattle, WA 98178
-            <br>
-            Description: Estimated coverage area currently lies between 42nd Ave S and Rainier Ave S going west to east,
-            and between S Cloverdale St and S Fletcher St going north to south. See green portions of the <a
-              href="https://drive.google.com/file/d/1u0-d55ELyP3Ipz7Urp6GHr3aNGYnvcbZ/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/SkywayLibrary.jpeg">
+            <img src="assets/static-maps/SkywayLibrary.jpeg" class="card-img-top" alt="A map of the Skyway Library coverage area.">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5>
+                <a href="assets/static-maps/SkywayLibrary.jpeg" class="card-title">KCLS Skyway Library Area</a>
+              </h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>
+                12601 76th Ave S, Seattle, WA 98178
+              </h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area currently lies between 42nd Ave S and Rainier Ave S going west to east,
+              and between S Cloverdale St and S Fletcher St going north to south. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for more details.
+            </p>
+          </div>
         </div>
       </div>
-
-      <div class="card flex-container-card">
-        <img src="assets/static-maps/SurgeTacoma.png" class="card-img-top" alt="...">
-        <div class="card-body">
-          <a href="https://surgecoworking.com/surge-tacoma/" class="site-name">Surge Tacoma</a>
-          <p class="card-texty img-wrapper">
-            Address: 2367 Tacoma Ave S, Tacoma, WA 98402
-            <br>
-            Description: Estimated coverage area lies to the south of S 11th St, east of MLK Jr. Way, west of the 705
-            highway, and north of Center St. See green portions of the <a
-              href="https://drive.google.com/file/d/10gZMUKZadWmA7aQxm8aeai2XcCS0YGqe/view?usp=sharing">image</a> and
-            the <a
-              href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a>
-            for more details.
-          </p>
-          <!--<div class="overlay-card">
-            <p> ... </p>
-          </div>-->
-        </div>
-      </div>
-    </div>
-    </div>
-    <div class = "basic-box">
-      <h2>Community Network Sites Map</h2>
-      <iframe src="https://www.google.com/maps/d/embed?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F&z=10&sll=47.551951079942704, -122.28761910549852" allowfullscreen class= "map"></iframe>
-    </div>
-
-    <div class="landing-tan" style="margin-bottom: 50px;" >
-      <h2> Coverage Map </h2>
-      <button onclick="location.href=''" type="button" id="network-button">
-        Our latest coverage estimates &rarr;
-      </button>
-    </div>
-
-    <!-- FOOTER -->
-    <div class="footer">
-      <div class="flex-container">
-        <div class="flex-item-left">
-          <h3> Address </h3>
-          <p class="footer-text">
-            3800 E Stevens Way NE, Seattle, WA 98195
-            <br>
-            lcl@seattlecommunitynetwork.org
-          </p>
-          <a href="https://www.instagram.com/seattlecommnet/"><img class="logo" src="assets/IG_icon_circle.png"
-              alt="Instagram logo"></a>
-          <a href="https://twitter.com/SeattleCommNet"><img class="logo" src="assets/twitter_icon_circle.png"
-              alt="twitter logo"></a>
-          <a href="https://www.facebook.com/SeattleCommNet"><img class="logo" src="assets/facebook_icon_circle.png"
-              alt="Facebook logo"></a>
-          <br><br>
-        </div>
-
-        <div class="flex-item-left">
-          <h3> Mission </h3>
-          <p class="footer-text">
-            To facilitate community focused technology development and
-            research in support of low-income, marginalized populations
-            and groups.
-          </p>
-        </div>
-
-        <div class="flex-item-left">
-          <div class="flex-item-left">
-            <button onclick="location.href='https://discord.gg/sZkK5RpeCE'" id="subscribe-button">
-              &nbsp; Join our Discord &nbsp;
-            </button>
-            <br><br>
-            <button
-              onclick="location.href='https://groups.google.com/a/seattlecommunitynetwork.org/g/local-connectivity-lab/'"
-              id="subscribe-button">
-              Subscribe to Mailing List
-            </button>
+      <div class="col-12 col-md-6 mb-4">
+        <div class="card">
+          <a href="assets/static-maps/SurgeTacoma.png">
+            <img src="assets/static-maps/SurgeTacoma.png" class="card-img-top" alt="A map of the Surge Tacoma coverage area.">
+          </a>
+          <div class="card-body">
+            <div class="card-title">
+              <h5>
+                <a href="assets/static-maps/SurgeTacoma.png" class="card-title">Surge Tacoma Area</a>
+              </h5>
+            </div>
+            <div class="card-subtitle">
+              <h6>
+                2367 Tacoma Ave S, Tacoma, WA 98402
+              </h6>
+            </div>
+            <p class="card-text">
+              Estimated coverage area lies to the south of S 11th St, east of MLK Jr. Way, west of the 705
+              highway, and north of Center St. See the <a href="https://www.google.com/maps/d/u/0/viewer?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F">map</a> for more details.
+            </p>
           </div>
         </div>
       </div>
     </div>
+  </div>
+  <div class = "basic-box">
+    <h2>Community Network Sites Map</h2>
+    <iframe src="https://www.google.com/maps/d/embed?mid=1T0TIZ7GL1eXlABPLaSM4DS9hW7-BoGhs&ehbc=2E312F&z=10&sll=47.551951079942704, -122.28761910549852" allowfullscreen class= "map"></iframe>
+  </div>
 
+  <div class="landing-tan" style="margin-bottom: 50px;" >
+    <h2> Coverage Map </h2>
+    <button onclick="location.href='https:\/\/coverage.seattlecommunitynetwork.org/'" type="button" id="network-button">
+      Our latest coverage estimates &rarr;
+    </button>
+  </div>
+
+  <!-- FOOTER -->
+  <div class="footer">
+    <div class="flex-container">
+      <div class="flex-item-left">
+        <h3> Address </h3>
+        <p class="footer-text">
+          3800 E Stevens Way NE, Seattle, WA 98195
+          <br>
+          lcl@seattlecommunitynetwork.org
+        </p>
+        <a href="https://www.instagram.com/seattlecommnet/"><img class="logo" src="assets/IG_icon_circle.png"
+            alt="Instagram logo"></a>
+        <a href="https://twitter.com/SeattleCommNet"><img class="logo" src="assets/twitter_icon_circle.png"
+            alt="twitter logo"></a>
+        <a href="https://www.facebook.com/SeattleCommNet"><img class="logo" src="assets/facebook_icon_circle.png"
+            alt="Facebook logo"></a>
+        <br><br>
+      </div>
+
+      <div class="flex-item-left">
+        <h3> Mission </h3>
+        <p class="footer-text">
+          To facilitate community focused technology development and
+          research in support of low-income, marginalized populations
+          and groups.
+        </p>
+      </div>
+
+      <div class="flex-item-left">
+        <div class="flex-item-left">
+          <button onclick="location.href='https://discord.gg/sZkK5RpeCE'" id="subscribe-button">
+            &nbsp; Join our Discord &nbsp;
+          </button>
+          <br><br>
+          <button
+            onclick="location.href='https://groups.google.com/a/seattlecommunitynetwork.org/g/local-connectivity-lab/'"
+            id="subscribe-button">
+            Subscribe to Mailing List
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/popper.js@1.12.9/dist/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.0.0/dist/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -202,6 +202,14 @@ p {
   font-size: 1em;
 }
 
+/*Remove Bootstrap 5 default anchor tag underlines unless hovered*/
+a:not([class*="btn"]) {
+  text-decoration: none;
+}
+a:not([class*="btn"]):hover {
+  text-decoration: underline;
+}
+
 /* IMAGE STYLING ************************************************/
 .largeImage {
   /*width: 599px;

--- a/style.css
+++ b/style.css
@@ -663,56 +663,20 @@ transform: rotate(-180deg);
   }
 }
 
-/* "OUR SITES" CARD STYLING *************************************************************/
+/* CARD STYLING ***************************************************************/
 .card {
-  /*max-width: 800px;
-  max-height: 600px;*/
-  width: 40%;
-  height: 25em;
-  margin-left: 5%;
-  margin-right: 5%;
-  margin-bottom: 3em;
-  margin-top: 1em;
-  filter: drop-shadow(0px 5px 20px rgba(0, 0, 0, 0.25));
+  box-shadow: 2px 2px 3px lightgray;
 }
 
-.card-title {
-  text-align: left;
-  margin-left: 2%;
-}
-
-.card-texty {
-  text-align: left;
+.card p {
+  font-size: 1rem;
+  padding: 0;
   margin: 0;
-  margin-left: -50px;
-  height: 50px;
-  /*overflow: hidden;*/
-  font-size: 0.8em;
 }
 
-.site-name {
-  margin: 0;
-  font-size: 1.2em;
-  margin-bottom: -10px;
-  color: #274B63;
-}
-
-.card-body {
-  background-color: #F1F1F1;
-  box-shadow: 0px 5px 20px rgba(0, 0, 0, 0.25);
-  height: 225px;
-  display: inline-block;
-
-}
-
-.card-img-top {
-  /*display: flex;
-  flex-direction: row;
-  flex-basis: 100%;
-  justify-content: center;
-  width: 15em;
-  height: 15em;*/
-  height: 100%;
+.card img {
+  width: 100%;
+  height: 20rem;
 }
 
 /* ACTIVITY *******************************************************************/
@@ -783,16 +747,6 @@ transform: rotate(-180deg);
     margin-left: 2em;
     margin-right: 2em;
   }
-
-  .card {
-    /*max-width: 800px;
-    max-height: 600px;*/
-    width: 80%;
-    height: 20em;
-    /*margin-left: auto;
-    margin-right: auto;*/
-  }
-
 }
 
 @media only screen and (max-width: 730px) {
@@ -800,15 +754,6 @@ transform: rotate(-180deg);
     flex-direction: column;
     margin-left: 15%;
     margin-right: 15%;
-  }
-
-  .card {
-    /*max-width: 800px;
-    max-height: 600px;*/
-    width: 80%;
-    height: 20em;
-    margin-left: auto;
-    margin-right: auto;
   }
 
   .site-name {


### PR DESCRIPTION
A live demo of the changes made with this PR can be found here: https://subtle-chebakia-745577.netlify.app/oursites

dc1f9ad is primarily focused on fixing issues with the way the location cards display on the ```ourSites.html``` page:
- Fixes bug where card text would overflow the card containers at various screen widths.
- Applies modern styling to cards, including titles and subtitles.
- Makes card images clickable to open full size map images.
- Switched card title hyperlinks from organization front pages to map images, as the front pages of these organizations did not discuss nor relate to coverage areas.
- Switched some map image hyperlinks from Google Docs to site assets folder to improve UX, as Google docs images are slower to load.
- Irrelevant card styling was removed from ```stylesheet.css```.

Small additional fixes:
- "Get Involved" link on ```index.html``` was broken, but is now fixed.
- "Our Latest Coverage Estimates" button at the bottom of ```ourSites.html``` was broken, but is now fixed.
- This PR implements the Bootstrap CDN instead of a local copy.

512bd16
- Additional commit to correct issue with out of date Bootstrap version.