### PR TITLE
fix prominent broken link on front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
   <div class="img-wrapper">
     <img id="city-graphic" src="assets/City Graphic.png" alt="image of buildings">
     <div class="overlay">
-      <button onclick="location.href='https://docs.seattlecommunitynetwork.org/get-started.html'" type="button"
+      <button onclick="location.href='https://docs.seattlecommunitynetwork.org/community/join.html'" type="button"
         id="get-involved-button">
         Get Involved &rarr;
       </button>


### PR DESCRIPTION
the link from the "Get Involved" text directed to a page that moved from `get-started.html` to `community/join.html` in commit 849ddb82d2b9814ed14c5496a5981d3ceeee1575